### PR TITLE
hotfix/rm retry logic

### DIFF
--- a/models/silver/retry/_pending_status.sql
+++ b/models/silver/retry/_pending_status.sql
@@ -2,9 +2,7 @@
     materialized = "ephemeral"
 ) }}
 
-
-
- WITH pending_tx AS (
+WITH pending_tx AS (
 
     SELECT
         block_number,
@@ -12,11 +10,10 @@
     FROM
         {{ ref('silver__transactions') }}
     WHERE
-        IS_PENDING = 'TRUE'
-
+        block_timestamp :: DATE = CURRENT_DATE() - 3
+        AND is_pending = 'TRUE'
 )
-
-select
+SELECT
     block_number,
     REPLACE(
         concat_ws('', '0x', to_char(block_number, 'XXXXXXXX')),
@@ -24,4 +21,5 @@ select
         ''
     ) AS block_number_hex,
     tx_hash
-from  pending_tx
+FROM
+    pending_tx

--- a/models/silver/streamline/realtime/streamline__blocks_realtime.sql
+++ b/models/silver/streamline/realtime/streamline__blocks_realtime.sql
@@ -53,14 +53,3 @@ SELECT
     ) AS params
 FROM
     tbl
-UNION
-SELECT
-    DISTINCT(block_number) AS block_number,
-    'eth_getBlockByNumber' AS method,
-    CONCAT(
-        block_number_hex,
-        '_-_',
-        'true'
-    ) AS params
-FROM
-    {{ ref("_pending_status") }}

--- a/models/silver/streamline/realtime/streamline__transactions_realtime.sql
+++ b/models/silver/streamline/realtime/streamline__transactions_realtime.sql
@@ -53,14 +53,3 @@ SELECT
     ) AS params
 FROM
     tbl
-UNION
-SELECT
-    DISTINCT(block_number) AS block_number,
-    'eth_getBlockByNumber' AS method,
-    CONCAT(
-        block_number_hex,
-        '_-_',
-        'false'
-    ) AS params
-FROM
-    {{ ref("_pending_status") }}

--- a/models/silver/streamline/realtime/streamline__tx_receipts_realtime.sql
+++ b/models/silver/streamline/realtime/streamline__tx_receipts_realtime.sql
@@ -57,10 +57,4 @@ SELECT
     tx_hash AS params
 FROM
     tbl
-UNION 
-SELECT
-    block_number,
-    'eth_getTransactionReceipt' AS method,
-    tx_hash AS params
-FROM
-    {{ ref("_pending_status") }}
+


### PR DESCRIPTION
Removing retry logic from models due to timeouts over weekend.
Retry logic is based on `is_pending` field which is going to be always true for the txs that are duplicates, reverted, or otherwise have no receipts due to the node issues.
